### PR TITLE
Update Attributes Ordering

### DIFF
--- a/docsbuild/content/migrations/realm.md
+++ b/docsbuild/content/migrations/realm.md
@@ -280,6 +280,26 @@ updates an attribute in the user profile for the realm
               - admin
 ```
 
+## updateRealmProfileOrder
+reorders attributes in the user profile for the realm based on the provided list
+
+### Parameters
+- realm: String, optional
+- order: List<String>, not optional — the list of attribute names in the desired order
+
+### Example
+```yaml
+    id: update-user-profile-order
+    author: amer.qwaider
+    changes:
+    - updateRealmProfileOrder:
+        order:
+          - lastName
+          - firstName
+          - email
+          - username
+```
+
 #### RealmAttributePermissions
 ##### Parameters
 - view: Set< String>, optional

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/ActionFactory.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/ActionFactory.kt
@@ -72,6 +72,7 @@ import de.klg71.keycloakmigration.changeControl.actions.realm.localization.Updat
 import de.klg71.keycloakmigration.changeControl.actions.realm.profile.AddRealmProfileAttributeAction
 import de.klg71.keycloakmigration.changeControl.actions.realm.profile.AddRealmProfileAttributeGroupAction
 import de.klg71.keycloakmigration.changeControl.actions.realm.profile.UpdateRealmProfileAttributeAction
+import de.klg71.keycloakmigration.changeControl.actions.realm.profile.UpdateRealmProfileOrderAction
 import de.klg71.keycloakmigration.changeControl.actions.requiredactions.UpdateRequiredActionAction
 import de.klg71.keycloakmigration.changeControl.actions.role.AddRoleAction
 import de.klg71.keycloakmigration.changeControl.actions.role.DeleteRoleAction
@@ -224,6 +225,7 @@ class ActionFactory(private val objectMapper: ObjectMapper) {
             "addRealmProfileAttributeGroup" -> objectMapper.readValue<AddRealmProfileAttributeGroupAction>(actionJson)
             "addRealmProfileAttribute" -> objectMapper.readValue<AddRealmProfileAttributeAction>(actionJson)
             "updateRealmProfileAttribute" -> objectMapper.readValue<UpdateRealmProfileAttributeAction>(actionJson)
+            "updateRealmProfileOrder" -> objectMapper.readValue<UpdateRealmProfileOrderAction>(actionJson)
 
             "addLocalizationEntry" -> objectMapper.readValue<AddLocalizationEntryAction>(actionJson)
             "updateLocalizationEntry" -> objectMapper.readValue<UpdateLocalizationEntryAction>(actionJson)

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/realm/profile/UpdateRealmProfileOrderAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/realm/profile/UpdateRealmProfileOrderAction.kt
@@ -1,0 +1,57 @@
+package de.klg71.keycloakmigration.changeControl.actions.realm.profile
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import de.klg71.keycloakmigration.changeControl.actions.Action
+import de.klg71.keycloakmigration.changeControl.actions.MigrationException
+import de.klg71.keycloakmigration.keycloakapi.model.RealmProfile
+import de.klg71.keycloakmigration.keycloakapi.realmExistsById
+
+class UpdateRealmProfileOrderAction(
+    realm: String?,
+    private val order: List<String>
+) : Action(realm) {
+
+    private lateinit var oldRealmProfile: RealmProfile
+
+    override fun execute() {
+        if (!client.realmExistsById(realm())) {
+            throw MigrationException("Realm with id: ${realm()} does not exist!")
+        }
+
+        val realmProfile = client.realmUserProfile(realm())
+
+        val mapper = jacksonObjectMapper()
+        oldRealmProfile = mapper.readValue(mapper.writeValueAsString(realmProfile), RealmProfile::class.java)
+
+        val existingAttributes = realmProfile.attributes
+
+        // Check if all entries in the new order exist in the current profile
+        order.forEach { attrName ->
+            if (existingAttributes.none { it.name == attrName }) {
+                throw MigrationException("Attribute '$attrName' does not exist in the realm profile!")
+            }
+        }
+
+        // Check if there are any attributes in the profile missing from the new order
+        val missingInOrder = existingAttributes.map { it.name }.filterNot { order.contains(it) }
+        if (missingInOrder.isNotEmpty()) {
+            throw MigrationException("Attributes missing in new order: $missingInOrder")
+        }
+
+        // Reorder attributes according to the order list
+        val reorderedAttributes = order.map { attrName ->
+            existingAttributes.first { it.name == attrName }
+        }
+
+        realmProfile.attributes.clear()
+        realmProfile.attributes.addAll(ArrayList(reorderedAttributes))
+
+        client.updateRealmProfile(realm(), realmProfile)
+    }
+
+    override fun undo() {
+        client.updateRealmProfile(realm(), oldRealmProfile)
+    }
+
+    override fun name() = "UpdateRealmProfileOrderAction $realm"
+}

--- a/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/realm/profile/UpdateRealmProfileOrderIntegTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/realm/profile/UpdateRealmProfileOrderIntegTest.kt
@@ -29,21 +29,20 @@ class UpdateRealmProfileOrderIntegTest : AbstractIntegrationTest() {
 
     @Test
     fun testReorderAttributes_AttributeInOrderNotInProfile_Throws() {
-        val invalidOrder = listOf("lastName", "nonExistentAttr", "email", "username")
+        val orderedAttributes = listOf("lastName", "extraAttribute", "email", "username")
 
         assertThatThrownBy {
-            UpdateRealmProfileOrderAction(testRealm, invalidOrder).executeIt()
+            UpdateRealmProfileOrderAction(testRealm, orderedAttributes).executeIt()
         }.isInstanceOf(MigrationException::class.java)
-            .hasMessageContaining("Attribute 'nonExistentAttr' does not exist in the realm profile!")
+            .hasMessageContaining("Attribute 'extraAttribute' does not exist in the realm profile!")
     }
 
     @Test
     fun testReorderAttributes_ProfileHasExtraAttr_Throws() {
-        val profileAttributes = client.realmUserProfile(testRealm).attributes.map { it.name }
-        val missingOrder = profileAttributes.filter { it != "username" }
+        val orderedAttributes = listOf("lastName", "firstName", "email")
 
         assertThatThrownBy {
-            UpdateRealmProfileOrderAction(testRealm, missingOrder).executeIt()
+            UpdateRealmProfileOrderAction(testRealm, orderedAttributes).executeIt()
         }.isInstanceOf(MigrationException::class.java)
             .hasMessageContaining("Attributes missing in new order: [username]")
 

--- a/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/realm/profile/UpdateRealmProfileOrderIntegTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/realm/profile/UpdateRealmProfileOrderIntegTest.kt
@@ -15,9 +15,6 @@ class UpdateRealmProfileOrderIntegTest : AbstractIntegrationTest() {
     fun testReorderAttributes_Success() {
         val orderedAttributes = listOf("lastName", "firstName", "email", "username")
 
-        val originalAttributes = client.realmUserProfile(testRealm).attributes
-        val originalNames = originalAttributes.map { it.name }
-
         UpdateRealmProfileOrderAction(
             testRealm,
             orderedAttributes

--- a/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/realm/profile/UpdateRealmProfileOrderIntegTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/realm/profile/UpdateRealmProfileOrderIntegTest.kt
@@ -1,0 +1,44 @@
+package de.klg71.keycloakmigration.changeControl.actions.realm.profile
+
+import de.klg71.keycloakmigration.AbstractIntegrationTest
+import de.klg71.keycloakmigration.changeControl.actions.MigrationException
+import de.klg71.keycloakmigration.keycloakapi.KeycloakClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.koin.core.component.inject
+
+class UpdateRealmProfileOrderIntegTest : AbstractIntegrationTest() {
+
+    private val client by inject<KeycloakClient>()
+
+    @Test
+    fun testReorderAttributes_Success() {
+        val orderedAttributes = listOf("lastName", "firstName", "email", "username")
+
+        val originalAttributes = client.realmUserProfile(testRealm).attributes
+        val originalNames = originalAttributes.map { it.name }
+
+        UpdateRealmProfileOrderAction(
+            testRealm,
+            orderedAttributes
+        ).executeIt()
+
+        val updatedAttributes = client.realmUserProfile(testRealm).attributes
+        val updatedNames = updatedAttributes.map { it.name }
+
+        assertThat(updatedNames).isEqualTo(orderedAttributes)
+    }
+
+    @Test(expected = MigrationException::class)
+    fun testReorderAttributes_AttributeInOrderNotInProfile_Throws() {
+        val invalidOrder = listOf("lastName", "nonExistentAttr", "email", "username")
+        UpdateRealmProfileOrderAction(testRealm, invalidOrder).executeIt()
+    }
+
+    @Test(expected = MigrationException::class)
+    fun testReorderAttributes_ProfileHasExtraAttr_Throws() {
+        val profileAttributes = client.realmUserProfile(testRealm).attributes.map { it.name }
+        val missingOrder = profileAttributes.drop(1)
+        UpdateRealmProfileOrderAction(testRealm, missingOrder).executeIt()
+    }
+}


### PR DESCRIPTION
Added a new action UpdateRealmProfileOrder, for re-ordering user profile attributes defined in realm settings.